### PR TITLE
Update scratch-blocks to remove Python 2 dependency

### DIFF
--- a/blockify.py
+++ b/blockify.py
@@ -327,8 +327,8 @@ with open(colours_js_orig) as f:
       lines[i] = '  "toolboxSelected": "#313131",\n'
     if '"toolboxSelected": ' in line:
       lines[i] = '  "toolboxSelected": "#313131",\n'
-    if '"text": ' in line:
-      lines[i] = '  "text": "#000000",\n'
+    if '"textFieldText": ' in line:
+      lines[i] = '  "textFieldText": "#000000",\n'
     if '"toolboxText": ' in line:
       lines[i] = '  "toolboxText": "#EEEEEE",\n'
 

--- a/blockify.py
+++ b/blockify.py
@@ -340,7 +340,9 @@ with open(colours_js_orig) as f:
 
   tertiary_saturation = module_hsl.get("tertiary_saturation")
   tertiary_lightness = module_hsl.get("tertiary_lightness")
-  
+
+  quaternary_saturation = module_hsl.get("quaternary_saturation")
+  quaternary_lightness = module_hsl.get("quaternary_lightness")  
 
   for module in modules:
     hue = module_hsl.get("hues").get(module.name, 0)
@@ -348,12 +350,14 @@ with open(colours_js_orig) as f:
     (pr, pg, pb) = hls_to_rgb(hue / 360, primary_lightness / 100, primary_saturation / 100)
     (sr, sg, sb) = hls_to_rgb(hue / 360, secondary_lightness / 100, secondary_saturation / 100)
     (tr, tg, tb) = hls_to_rgb(hue / 360, tertiary_lightness / 100, tertiary_saturation / 100)
+    (qr, qg, qb) = hls_to_rgb(hue / 360, quaternary_lightness / 100, quaternary_saturation / 100)
 
     lines.insert(25, "  '" + module.name + "': {\n")
     lines.insert(26, "    'primary': '#%02x%02x%02x',\n" % (int(pr * 255), int(pg * 255), int(pb * 255)))
     lines.insert(26, "    'secondary': '#%02x%02x%02x',\n" % (int(sr * 255), int(sg * 255), int(sb * 255)))
-    lines.insert(28, "    'tertiary': '#%02x%02x%02x'\n" % (int(tr * 255), int(tg * 255), int(tb * 255)))
-    lines.insert(29, "  },\n")
+    lines.insert(28, "    'tertiary': '#%02x%02x%02x',\n" % (int(tr * 255), int(tg * 255), int(tb * 255)))
+    lines.insert(29, "    'quaternary': '#%02x%02x%02x'\n" % (int(qr * 255), int(qg * 255), int(qb * 255)))
+    lines.insert(30, "  },\n")
   with open(colours_js_path, 'w') as f:
     f.writelines(lines)
 

--- a/blockify.py
+++ b/blockify.py
@@ -627,13 +627,13 @@ with open(vertical_extensions_js_orig) as f:
   category_names += "];\n"
   
   
-  # Replace the 223rd line
+  # Replace the 225th line
   lines = f.readlines()
-  lines[222] = category_names
+  lines[224] = category_names
 
-  # Delete line 224 and 225
-  lines.pop(223)
-  lines.pop(223)
+  # Delete line 226 and 227
+  lines.pop(225)
+  lines.pop(225)
 
   with open(vertical_extensions_js_path, 'w') as f:
     f.writelines(lines)

--- a/module_hsl.json
+++ b/module_hsl.json
@@ -5,6 +5,8 @@
   "secondary_lightness": 49.0,
   "tertiary_saturation": 36.4,
   "tertiary_lightness": 42.0,
+  "quaternary_saturation": 34.4,
+  "quaternary_lightness": 35.0,
   "hues": {
     "wait_for": 20,
     "time": 50,


### PR DESCRIPTION
Updates `scratch-blocks` to v1.1.206. The main motivation is to remove our build dependency on Python 2. Our current version of `scratch-blocks` requires Python 2, but newer versions do not. The dependency was causing problems for Simulator, and Python 2 is no longer supported anyway.

There were other changes in `scratch-blocks` between our current version and v1.1.206 that required minor changes in the `blockify` and `build` scripts, including:
- Renaming of fields, like `text` to `textFieldText`
- Introduction of quaternary colors, which are required